### PR TITLE
Fix token cleanup in password reset

### DIFF
--- a/CapitalHub/Backend/controllers/usuarioController.js
+++ b/CapitalHub/Backend/controllers/usuarioController.js
@@ -433,8 +433,15 @@ exports.resetPassword = async (req, res) => {
   await user.save();
 
   // Revocar todos los tokens activos
+  const relations = await UsuarioToken.findAll({
+    where: { id_usuario: user.id_usuario },
+    attributes: ['id_token']
+  });
+  const tokenIds = relations.map(r => r.id_token);
   await UsuarioToken.destroy({ where: { id_usuario: user.id_usuario } });
-  await Token.destroy({ where: { id_token: null } }); // o filtrar por usuario
+  if (tokenIds.length) {
+    await Token.destroy({ where: { id_token: tokenIds } });
+  }
 
   res.json({ mensaje: 'Contraseña restablecida con éxito' });
 };


### PR DESCRIPTION
## Summary
- revoke all active tokens when a user resets their password

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68456b37aad883338abddf8dcf200a2a